### PR TITLE
Init row

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/*

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = function (opts, hexes) {
         if (x > rsize.width - hsize.width) {
             y += Math.floor(hsize.height * 3/4) + spacing;
             row ++;
-            x = (row % 2 ? hsize.width / 2 : 0) + (spacing / 2);
+            x = (row % 2 ? (hsize.width / 2) + (spacing / 2) : 0);
         }
     }
     var res = {

--- a/index.js
+++ b/index.js
@@ -23,8 +23,14 @@ module.exports = function (opts, hexes) {
             y: defined(opts.offsetTop, 0)
         };
     }
-    
-    var x = 0, y = 0, row = 0;
+    var initRow = defined(opts.initRow, 0);
+    initRow = parseInt(initRow, 10);
+    if (initRow > 1) initRow = 1;
+    if (initRow < 0) initRow = 0;
+
+    var x = (initRow === 1) ? (hsize.width / 2) + (spacing / 2) : 0;
+    var y = 0;
+    var row = initRow;
     var results = [], points = [];
     for (var i = 0; i < hexes.length; i++) {
         var hex = hexes[i];
@@ -34,7 +40,7 @@ module.exports = function (opts, hexes) {
             hex.style.top = y;
         }
         results.push({ x: x, y: y });
-        
+
         var hw = hsize.width / 2, hh = hsize.height / 2;
         var cx = x + hw, cy = y + hh;
         var pts = [
@@ -46,7 +52,7 @@ module.exports = function (opts, hexes) {
             [ cx - hw, cy - hh / 2 ]
         ];
         points.push(pts);
-        
+
         x += hsize.width + spacing;
         if (x > rsize.width - hsize.width) {
             y += Math.floor(hsize.height * 3/4) + spacing;


### PR DESCRIPTION
Allow customizing of the initial row for more flexible layout options. This also fixes a small bug w/ the positioning of even rows when spacing is provided.

Spacing issue before:

![screen shot 2014-11-03 at 9 50 22 pm](https://cloud.githubusercontent.com/assets/22249/4895292/8f944f8e-63e6-11e4-812e-a61cfb7082e6.png)

Spacing issue after:

![screen shot 2014-11-03 at 9 51 42 pm](https://cloud.githubusercontent.com/assets/22249/4895293/b2e2d85c-63e6-11e4-81cd-0e896e439792.png)

w/o initRow:

![screen shot 2014-11-03 at 9 52 33 pm](https://cloud.githubusercontent.com/assets/22249/4895301/e1b4b5c4-63e6-11e4-9843-a8516eff1048.png)

w/ initRow:

![screen shot 2014-11-03 at 9 52 57 pm](https://cloud.githubusercontent.com/assets/22249/4895304/ec536336-63e6-11e4-867c-d6a568d444d8.png)
